### PR TITLE
Workaround for legacy Ruby 1.8 Global Interpreter Lock handling.

### DIFF
--- a/ruby-lorcon/Lorcon2.c
+++ b/ruby-lorcon/Lorcon2.c
@@ -530,12 +530,12 @@ static VALUE Lorcon_capture_next(VALUE self) {
 	Data_Get_Struct(self, struct rldev, rld);
 
 	pd = lorcon_get_pcap(rld->context);
-	
-#ifndef RUBY_19
+
+#ifdef RUBY_18
 	TRAP_BEG;
 #endif
 	ret = pcap_dispatch(pd, 1, (pcap_handler) rblorcon_pcap_handler, (u_char *)&job);
-#ifndef RUBY_19
+#ifdef RUBY_18
 	TRAP_END;
 #endif
 		

--- a/ruby-lorcon/README
+++ b/ruby-lorcon/README
@@ -3,13 +3,13 @@ developed by Joshua Wright and dragorn. This interface is only
 available on Linux and with lorcon-supported wireless drivers.
 
 For more information, please see the lorcon documentation and code:
-http://www.802.11mercenary.net/lorcon/
+https://github.com/kismetwireless/lorcon/
 
 To build this extension:
 
 1) Download, compile, and install lorcon
 The latest version of lorcon can pulled from SVN:
-$ svn co https://802.11ninja.net/svn/lorcon/trunk/ lorcon
+$ git clone https://github.com/kismetwireless/lorcon.git lorcon
 $ cd lorcon
 $ ./configure
 $ make

--- a/ruby-lorcon/extconf.rb
+++ b/ruby-lorcon/extconf.rb
@@ -4,6 +4,10 @@ require 'mkmf'
 
 $CFLAGS += " -I/usr/include/lorcon2"
 
+if ( RUBY_VERSION =~ /^(1\.8)/ )
+	$CFLAGS += " -DRUBY_18"
+end
+
 if ( RUBY_VERSION =~ /^(1\.9|2\.0)/ )
 	$CFLAGS += " -DRUBY_19"
 end

--- a/ruby-lorcon/ruby-lorcon.gemspec
+++ b/ruby-lorcon/ruby-lorcon.gemspec
@@ -1,0 +1,17 @@
+Gem::Specification.new do |s|
+  s.licenses      = ['GPL-2.0']
+  s.authors       = ['dragorn', 'Joshua Wright']
+  s.email         = ['msfdev@metasploit.com']
+  s.name          = 'ruby-lorcon'
+  s.version       = '0.2.0'
+  s.date          = '2017-12-13'
+  s.summary       = 'This is an experimental interface for lorcon.'
+  s.homepage      = 'https://github.com/kismetwireless/lorcon/tree/master/ruby-lorcon'
+  s.metadata    = { "source_code_uri" => "https://github.com/kismetwireless/lorcon.git" }
+  s.description   = 'This interface is only available on Linux and with lorcon-supported wireless drivers.'
+  s.files         = [ 'README',
+                      'extconf.rb',
+                      'Lorcon2.c',
+                      'Lorcon2.h' ]
+  s.extensions    = [ 'extconf.rb' ]
+end


### PR DESCRIPTION
TRAP_BEG and TRAP_END are deprecated. Lorcon_capture_next() is likely broken.

This is related to the Ruby Global Interpreter Lock (GIL)

See detail in "Threading Basics" from http://old.blog.phusion.nl/category/ruby/page/2/
- on Ruby 1.8 you should surround system calls with TRAP_BEG and TRAP_END - https://docs.ruby-lang.org/en/2.2.0/ChangeLog-1_8_0.html
- rb_thread_blocking_region() is a Ruby 1.9-specific function which allows you to call a function outside the global interpreter lock that should be used instead of TRAP_* macros
- rb_thread_blocking_region() is subsequently deprecated in Ruby 2.2 - https://bugs.ruby-lang.org/issues/5543
- The equivalent Macros are defined as follows in Ruby 2.2 (showing the pedigree of all the above functions):
191 193 rb_thread_blocking_region_begin -> rb_thread_call_without_gvl family
191 193 rb_thread_blocking_region_end -> rb_thread_call_without_gvl family
old 193 TRAP_BEG -> rb_thread_call_without_gvl family
old 193 TRAP_END -> rb_thread_call_without_gvl family

See current documentation here on properly using the replacement function rb_thread_call_without_gvl() here: https://github.com/ruby/ruby/blob/v2_0_0_247/thread.c#L1231-L1315

As stated above it is likely that Lorcon_capture_next() has been broken for some time now, and something will likely need to be done to make it work properly. I am not currently aware of anyone using this function via ruby-lorcon. Metasploit specific tools are sending packets, not reading them... 

Examples of this issue:
https://forum.aircrack-ng.org/index.php?topic=1445.0
https://unix.stackexchange.com/questions/311724/kali-linux-unable-to-make-airdrop-ng-lorcon-pylorcon2
https://www.reddit.com/r/Kalilinux/comments/52723q/how_to_install_airdrop/

This has lead to complaints of Lorcon being unmaintained, and has lead to Metasploit maintainers pulling it from the project:

Lorcon & all the wifi modules were removed from Metasploit in Feb of 2015
https://github.com/rapid7/metasploit-framework/pull/4850
https://github.com/rapid7/metasploit-framework/pull/3200

I have added a Gem to help with the concerns mentioned in the threads above. 
https://rubygems.org/gems/ruby-lorcon
https://github.com/DJISDKUser/lorcon/commit/3b37fcd4add761ebdddfbba009f4b3e3bdc0bcd6

