### PR TITLE
fix 80211 header source addr order

### DIFF
--- a/lorcon_forge.c
+++ b/lorcon_forge.c
@@ -170,11 +170,12 @@ void lcpf_80211headers(struct lcpa_metapack *pack, unsigned int type,
 		pack = lcpa_append_copy(pack, "80211MAC2", 6, mac2);
 	if (mac3 != NULL)
 		pack = lcpa_append_copy(pack, "80211MAC3", 6, mac3);
-	if (mac4 != NULL)
-		pack = lcpa_append_copy(pack, "80211MAC4", 6, mac4);
-
+	
 	*sixptr = ((sequence << 4) | fragment);
 	pack = lcpa_append_copy(pack, "80211FRAGSEQ", 2, chunk);
+	
+	if (mac4 != NULL)
+		pack = lcpa_append_copy(pack, "80211MAC4", 6, mac4);
 }
 
 void lcpf_beacon(struct lcpa_metapack *pack, uint8_t *src, uint8_t *bssid, 


### PR DESCRIPTION
The fragment and sequence are located in front of the source address inside the MAC header.

Currently the fragment and sequence id are interpreted as part of the source address (which should equal the TX addr. in the case below) by the receiver.

In the following capture, the TX, RX, src and dest addr. should all be 00:16:ea:12:34:56, but  the 00:16 are interpreted as fragment and sequence nibbles and the mac becomes ea:12:34:56:[fragment_sequence].
![oneTypo](https://user-images.githubusercontent.com/60760282/83974619-0a333680-a8ef-11ea-8dd7-d907300c6dd1.png)
