### PR TITLE
Remove include for rubysig.h

### DIFF
--- a/ruby-lorcon/Lorcon2.c
+++ b/ruby-lorcon/Lorcon2.c
@@ -1,10 +1,6 @@
 #include "Lorcon2.h"
 #include "ruby.h"
 
-#ifndef RUBY_19
-#include "rubysig.h"
-#endif
-
 /*
 	self.license = GPLv2;
 */


### PR DESCRIPTION
Ruby has deprecated rubysig.h, and the ifdef looks for 1.9 which
enables the #include compiler directive under Ruby 3.
Drop the entire ifdef block which allows compilation under Ruby 3.